### PR TITLE
Remove context_processor required to run library.

### DIFF
--- a/django_react_templatetags/context_processors.py
+++ b/django_react_templatetags/context_processors.py
@@ -4,6 +4,7 @@
 
 def react_context_processor(request):
     """Expose a global list of react components to be processed"""
+    print("react_context_processor is no longer required.")
 
     return {
         'REACT_COMPONENTS': [],

--- a/django_react_templatetags/templatetags/react.py
+++ b/django_react_templatetags/templatetags/react.py
@@ -18,7 +18,6 @@ from django_react_templatetags.encoders import json_encoder_cls_factory
 register = template.Library()
 
 CONTEXT_KEY = "REACT_COMPONENTS"
-CONTEXT_PROCESSOR = 'django_react_templatetags.context_processors.react_context_processor'  # NOQA
 
 DEFAULT_SSR_HEADERS = {
     'Content-type': 'application/json',
@@ -42,15 +41,6 @@ def get_ssr_headers():
     if not hasattr(settings, 'REACT_RENDER_HEADERS'):
         return DEFAULT_SSR_HEADERS
     return settings.REACT_RENDER_HEADERS
-
-
-def has_context_processor():
-    try:
-        status = CONTEXT_PROCESSOR in settings.TEMPLATES[0]['OPTIONS']['context_processors']  # NOQA
-    except Exception as e:  # NOQA
-        status = False
-
-    return status
 
 
 def load_from_ssr(component, ssr_context=None):
@@ -94,9 +84,6 @@ class ReactTagManager(Node):
         self.ssr_context = ssr_context
 
     def render(self, context):
-        if not has_context_processor():
-            raise Exception('"react_context_processor must be added to TEMPLATE_CONTEXT_PROCESSORS"')  # NOQA
-
         qualified_component_name = self.get_qualified_name(context)
         identifier = self.get_identifier(context, qualified_component_name)
         component_props = self.get_component_props(context)
@@ -263,7 +250,7 @@ def react_print(context):
     Example:
         {% react_print %}
     """
-    components = context[CONTEXT_KEY]
+    components = context.get(CONTEXT_KEY, [])
     context[CONTEXT_KEY] = []
 
     new_context = context.__copy__()

--- a/django_react_templatetags/tests/demosite/settings.py
+++ b/django_react_templatetags/tests/demosite/settings.py
@@ -57,7 +57,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'django_react_templatetags.context_processors.react_context_processor',
             ],
         },
     },

--- a/example_django_react_templatetags/examplesite/settings.py
+++ b/example_django_react_templatetags/examplesite/settings.py
@@ -63,7 +63,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'django_react_templatetags.context_processors.react_context_processor',
             ],
         },
     },


### PR DESCRIPTION
The context processor was providing an initial empty list of rendered components in order to include them in the `{% react_print %}` output. While [render would anyway fallback to an empty list](https://github.com/Frojd/django-react-templatetags/blob/develop/django_react_templatetags/templatetags/react.py#L110) in case of no variable in current context, [the library would throw a KeyError](https://github.com/Frojd/django-react-templatetags/blob/develop/django_react_templatetags/templatetags/react.py#L266) when running the `{% react_print %}`.

The rationale behind this change is that the CP itself doesn't provide any significant value there and the list in the context can be dynamically created when rendering the first react component on the page. 

On the contrary, when using `render_to_string` which has no request context, the library would throw the `KeyError` mentioned before.