### PR TITLE
Don't print script tag if no react components

### DIFF
--- a/django_react_templatetags/templates/react_print.html
+++ b/django_react_templatetags/templates/react_print.html
@@ -1,3 +1,4 @@
+{% if components %}
 <script>
     {% for component in components %}
         ReactDOM.{{ ssr_available|yesno:"hydrate,render" }}(
@@ -11,3 +12,4 @@
         );
     {% endfor %}
 </script>
+{% endif %}


### PR DESCRIPTION
I have found that in some browsers, a blank script tag is a syntax error. No need to output an empty script tag if there is no react component to render.