### PR TITLE
Add React 18 support

### DIFF
--- a/django_react_templatetags/templates/react_print.html
+++ b/django_react_templatetags/templates/react_print.html
@@ -2,14 +2,34 @@
     {% for component in components %}
         {{ component.json_obj|json_script:component.data_identifier }}
         <script>
-            ReactDOM.{{ ssr_available|yesno:"hydrate,render" }}(
-                React.createElement({{ component.name }}, JSON.parse(document.getElementById("{{ component.data_identifier }}").textContent)),
-            {% if ssr_available and component.ssr_params.hypernova_id %}
-                document.querySelector('div[data-hypernova-id="{{ component.ssr_params.hypernova_id }}"]')
-            {% else %}
-                document.getElementById('{{ component.identifier }}')
-            {% endif %}
-            );
+            var react18VersionKey = "DjangoReactTemplatetags_ReactMajorVersion";
+
+            if (typeof window !== "undefined" && !window[react18VersionKey] && window.React) {
+                window[react18VersionKey] = parseInt(React.version.split(".")[0]);
+            }
+
+            if (window[react18VersionKey] >= 18) {
+                {% if ssr_available and component.ssr_params.hypernova_id %}
+                    const domNode = document.querySelector('div[data-hypernova-id="{{ component.ssr_params.hypernova_id }}"]');
+                    ReactDOM.hydrateRoot(domNode, 
+                        React.createElement({{ component.name }}, JSON.parse(document.getElementById("{{ component.data_identifier }}").textContent))
+                    );
+                {% else %}
+                    const domNode = document.getElementById('{{ component.identifier }}');
+                    ReactDOM.createRoot(domNode).render(
+                        React.createElement({{ component.name }}, JSON.parse(document.getElementById("{{ component.data_identifier }}").textContent))
+                    );
+                {% endif %}
+            } else {
+                ReactDOM.{{ ssr_available|yesno:"hydrate,render" }}(
+                    React.createElement({{ component.name }}, JSON.parse(document.getElementById("{{ component.data_identifier }}").textContent)),
+                    {% if ssr_available and component.ssr_params.hypernova_id %}
+                    document.querySelector('div[data-hypernova-id="{{ component.ssr_params.hypernova_id }}"]')
+                    {% else %}
+                    document.getElementById('{{ component.identifier }}')
+                    {% endif %}
+                    );
+            }
         </script>
     {% endfor %}
 {% endif %}

--- a/django_react_templatetags/templates/react_print.html
+++ b/django_react_templatetags/templates/react_print.html
@@ -23,12 +23,12 @@
             } else {
                 ReactDOM.{{ ssr_available|yesno:"hydrate,render" }}(
                     React.createElement({{ component.name }}, JSON.parse(document.getElementById("{{ component.data_identifier }}").textContent)),
-                    {% if ssr_available and component.ssr_params.hypernova_id %}
+                {% if ssr_available and component.ssr_params.hypernova_id %}
                     document.querySelector('div[data-hypernova-id="{{ component.ssr_params.hypernova_id }}"]')
-                    {% else %}
+                {% else %}
                     document.getElementById('{{ component.identifier }}')
-                    {% endif %}
-                    );
+                {% endif %}
+                );
             }
         </script>
     {% endfor %}


### PR DESCRIPTION
This is a proposal to add support for React 18. For React 18, `ReactDOM.render` and `ReactDOM.hydrate` are deprecated, so the new `ReactDOM.createRoot` and `ReactDOM.hydrateRoot` methods must be used:

https://react.dev/reference/react-dom/client/createRoot#createroot
https://react.dev/reference/react-dom/client/hydrateRoot#hydrateroot

Since the SSR examples are quite old and Hypernova has also been deprecated, I have not yet been able to extensively test the case where `hydrateRoot` is used. Unfortunately, I can no longer get the old [SSR examples](https://github.com/marteinn/django-react-polls-with-hypernova-examples) to work because the node version is too old 🙂. Can you check if it works or let me know how I can test it?